### PR TITLE
'/dev/null' bug when running data_fabric in a windows environment

### DIFF
--- a/lib/data_fabric.rb
+++ b/lib/data_fabric.rb
@@ -41,7 +41,8 @@ require 'data_fabric/version'
 module DataFabric
 
   def self.logger
-    @logger ||= ActiveRecord::Base.logger || Logger.new('/dev/null')
+    devnull = RUBY_PLATFORM =~ /w32/ ? 'nul' : '/dev/null'
+    @logger ||= ActiveRecord::Base.logger || Logger.new(devnull)
   end
   
   def self.logger=(log)


### PR DESCRIPTION
I ran into a small bug when running data_fabric in a windows environment. In the self.logger method, '/dev/null' is a unix thing, so Windows throws a file not found error.

I'm running Windows on Parallels, so RUBY_PLATFORM in that case is "i386-mingw32". On the Snow Leopard side it's "x86_64-darwin10.7.1". From trial and error I found that the regex /w32/ worked for me. 
