### PR TITLE
Connection re-use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.bundle/config
+/bin
+/bundle
+/test/*.db

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+gem 'rake'
+gem 'flexmock'
+gem 'activerecord', '2.3.10'
+gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activerecord (2.3.10)
+      activesupport (= 2.3.10)
+    activesupport (2.3.10)
+    flexmock (0.9.0)
+    rake (0.9.2)
+    sqlite3 (1.3.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (= 2.3.10)
+  flexmock
+  rake
+  sqlite3

--- a/data_fabric.gemspec
+++ b/data_fabric.gemspec
@@ -1,4 +1,4 @@
-require './lib/data_fabric/version'
+require File.expand_path('../lib/data_fabric/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.version = DataFabric::Version::STRING

--- a/example23/.gitignore
+++ b/example23/.gitignore
@@ -1,0 +1,6 @@
+/.bundle/config
+/bin
+/db/*.sqlite3
+/db/schema.rb
+/log
+/vendor

--- a/example23/Gemfile
+++ b/example23/Gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+gem 'rake'
+gem 'rails', '2.3.10'
+gem "data_fabric", :path => File.expand_path('../../', __FILE__)
+gem 'sqlite3-ruby'

--- a/example23/Gemfile.lock
+++ b/example23/Gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: /Users/jason/projects/data_fabric
+  specs:
+    data_fabric (1.3.2)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    actionmailer (2.3.10)
+      actionpack (= 2.3.10)
+    actionpack (2.3.10)
+      activesupport (= 2.3.10)
+      rack (~> 1.1.0)
+    activerecord (2.3.10)
+      activesupport (= 2.3.10)
+    activeresource (2.3.10)
+      activesupport (= 2.3.10)
+    activesupport (2.3.10)
+    rack (1.1.2)
+    rails (2.3.10)
+      actionmailer (= 2.3.10)
+      actionpack (= 2.3.10)
+      activerecord (= 2.3.10)
+      activeresource (= 2.3.10)
+      activesupport (= 2.3.10)
+      rake (>= 0.8.3)
+    rake (0.9.2)
+    sqlite3 (1.3.3)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  data_fabric!
+  rails (= 2.3.10)
+  rake
+  sqlite3-ruby

--- a/example23/Rakefile
+++ b/example23/Rakefile
@@ -47,12 +47,7 @@ task :test do
 end
 
 namespace :app do
-  task :prepare => [:clean, :copy_plugin, :migrate]
-
-  task :copy_plugin do
-    mkdir_p 'vendor/gems/data_fabric-1.0.0'
-    cp_r '../lib', 'vendor/gems/data_fabric-1.0.0'
-  end
+  task :prepare => [:clean, :migrate]
 
   task :clean do
     rm_rf 'log'

--- a/example23/config/boot.rb
+++ b/example23/config/boot.rb
@@ -105,5 +105,19 @@ module Rails
   end
 end
 
+class Rails::Boot
+  def run
+    load_initializer
+
+    Rails::Initializer.class_eval do
+      def load_gems
+        @bundler_loaded ||= Bundler.require :default, Rails.env
+      end
+    end
+
+    Rails::Initializer.run(:set_load_path)
+  end
+end
+
 # All that for this:
 Rails.boot!

--- a/example23/config/preinitializer.rb
+++ b/example23/config/preinitializer.rb
@@ -1,0 +1,20 @@
+begin
+  require "rubygems"
+  require "bundler"
+rescue LoadError
+  raise "Could not load the bundler gem. Install it with `gem install bundler`."
+end
+
+if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("0.9.24")
+  raise RuntimeError, "Your bundler version is too old for Rails 2.3." +
+   "Run `gem install bundler` to upgrade."
+end
+
+begin
+  # Set up load paths for all bundled gems
+  ENV["BUNDLE_GEMFILE"] = File.expand_path("../../Gemfile", __FILE__)
+  Bundler.setup
+rescue Bundler::GemNotFound
+  raise RuntimeError, "Bundler couldn't find some gems." +
+    "Did you run `bundle install`?"
+end

--- a/example30/.gitignore
+++ b/example30/.gitignore
@@ -2,3 +2,6 @@
 db/*.sqlite3
 log/*.log
 tmp/**/*
+/bin
+/db/schema.rb
+/vendor/bundle

--- a/lib/data_fabric.rb
+++ b/lib/data_fabric.rb
@@ -2,7 +2,7 @@ require 'active_record'
 require 'active_record/version'
 require 'active_record/connection_adapters/abstract/connection_pool'
 require 'active_record/connection_adapters/abstract/connection_specification'
-require 'data_fabric/version'
+require File.expand_path('../data_fabric/version', __FILE__)
 
 # DataFabric adds a new level of flexibility to ActiveRecord connection handling.
 # You need to describe the topology for your database infrastructure in your model(s).  As with ActiveRecord normally, different models can use different topologies.

--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -120,7 +120,11 @@ module DataFabric
       self.class.shard_pools[name] ||= begin
         config = ActiveRecord::Base.configurations[name]
         raise ArgumentError, "Unknown database config: #{name}, have #{ActiveRecord::Base.configurations.inspect}" unless config
-        ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec_for(config))
+        existing_equivalent_connection = self.class.shard_pools.detect do |name, conn|
+          config == conn.spec.config
+        end
+        existing_equivalent_connection ||
+          ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec_for(config))
       end
     end
     

--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -120,8 +120,8 @@ module DataFabric
       self.class.shard_pools[name] ||= begin
         config = ActiveRecord::Base.configurations[name]
         raise ArgumentError, "Unknown database config: #{name}, have #{ActiveRecord::Base.configurations.inspect}" unless config
-        existing_equivalent_connection = self.class.shard_pools.detect do |name, conn|
-          config == conn.spec.config
+        n, existing_equivalent_connection = self.class.shard_pools.detect do |name, conn|
+          config.stringify_keys == conn.spec.config.stringify_keys
         end
         existing_equivalent_connection ||
           ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec_for(config))

--- a/lib/data_fabric/version.rb
+++ b/lib/data_fabric/version.rb
@@ -1,5 +1,5 @@
 module DataFabric
   module Version
-    STRING = '1.3.2'
+    STRING = '1.3.2.1'
   end
 end

--- a/test/database.yml
+++ b/test/database.yml
@@ -22,3 +22,11 @@ fiveruns_city_dallas_test_master:
 fiveruns_city_dallas_test_slave:
   adapter: sqlite3
   database: test/vr_dallas_slave.db
+
+fiveruns_city_austin_burb_test_master:
+  adapter: sqlite3
+  database: test/vr_austin_master.db
+
+fiveruns_city_austin_burb_test_slave:
+  adapter: sqlite3
+  database: test/vr_austin_slave.db


### PR DESCRIPTION
We were running into connection limit issues with mysql when using multiple :shard_by values.  We're sharding different models differently, but to the same set of shards, so we end up duplicating connections that are the same for all intents and purposes.  I made a change that searches through shard_pools looking for an connection to the same DB before creating a new connection.  This reduced our number of DB connections by half.

I also added a test for this.  In order to ease my life when testing I setup everything with bundler, which I'm hoping you'll pull in as well.

Thanks,
Jason
