### PR TITLE
Implement respond_to? on ConnectionProxy to match what the class actually

### DIFF
--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -89,6 +89,10 @@ module DataFabric
       end
     end
 
+    def respond_to?(method)
+      super || connection.respond_to?(method)
+    end
+
     def method_missing(method, *args, &block)
       DataFabric.logger.debug { "Calling #{method} on #{connection}" }
       connection.send(method, *args, &block)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -78,7 +78,24 @@ class ConnectionTest < Test::Unit::TestCase
       ShardModel.connection.connection_name
     end
   end
-  
+
+  def test_respond_to_connection_methods
+    setup_configuration_for ShardModel, 'city_austin_test'
+    DataFabric.activate_shard(:city => 'austin', :category => 'art') do
+      assert ShardModel.connection.respond_to?(:columns)
+      assert ShardModel.connection.respond_to?(:primary_key)
+      assert !ShardModel.connection.respond_to?(:nonexistent_method)
+    end
+  end
+
+  def test_respond_to_connection_proxy_methods
+    setup_configuration_for ShardModel, 'city_austin_test'
+    DataFabric.activate_shard(:city => 'austin', :category => 'art') do
+      assert ShardModel.connection.respond_to?(:with_master)
+      assert !ShardModel.connection.respond_to?(:nonexistent_method)
+    end
+  end
+
   def test_enchilada
     setup_configuration_for TheWholeEnchilada, 'fiveruns_city_dallas_test_slave'
     setup_configuration_for TheWholeEnchilada, 'fiveruns_city_dallas_test_master'


### PR DESCRIPTION
Implement respond_to? on ConnectionProxy to match what the class actually performs via method_missing.

There are a bunch of forks which implement specific methods, but we thought it would be better to just cover them all with respond_to?
