### PR TITLE
Remove code that changes the behavior of nested transactions

### DIFF
--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -79,13 +79,8 @@ module DataFabric
     delegate :insert_many, :to => :master # ar-extensions bulk insert support
 
     def transaction(start_db_transaction = true, &block)
-      # Transaction is not re-entrant in SQLite 3 so we
-      # need to track if we've already started an XA to avoid
-      # calling it twice.
-      return yield if in_transaction?
-
       with_master do
-        connection.transaction(start_db_transaction, &block) 
+        connection.transaction(start_db_transaction, &block)
       end
     end
 
@@ -125,10 +120,6 @@ module DataFabric
     end
     
     private
-
-    def in_transaction?
-      current_role == 'master'
-    end
 
     def spec_for(config)
       # XXX This looks pretty fragile.  Will break if AR changes how it initializes connections and adapters.


### PR DESCRIPTION
Remove code that changes the behavior of nested transactions since it doesn't work with postgresql and sqlite3 seems to be ok without it.

We couldn't figure out a good way to write a test across multiple databases. We tested it in our app with postgres, and we tested it in the data_fabric app with sqlite3.
