### PR TITLE
Avoid calling alias method chain twice and triggering stack too deep errors

### DIFF
--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -1,7 +1,9 @@
 module DataFabric
   module ActiveRecordConnectionMethods
     def self.included(base)
-      base.alias_method_chain :reload, :master
+      unless base.method_defined? :reload_without_master
+        base.alias_method_chain :reload, :master
+      end
     end
 
     def reload_with_master(*args, &block)


### PR DESCRIPTION
We were running into this with STI and having data_fabric on the parent and child class.
