### PR TITLE
Update lib/data_fabric/connection_proxy.rb

### DIFF
--- a/lib/data_fabric/connection_proxy.rb
+++ b/lib/data_fabric/connection_proxy.rb
@@ -120,7 +120,7 @@ module DataFabric
       name = connection_name
       self.class.shard_pools[name] ||= begin
         config = ActiveRecord::Base.configurations[name]
-        raise ArgumentError, "Unknown database config: #{name}, have #{ActiveRecord::Base.configurations.inspect}" unless config
+        raise ArgumentError, "Unknown database config: #{name}" unless config
         ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec_for(config))
       end
     end


### PR DESCRIPTION
It's a bit dangerous to dump the full database config (which includes passwords) into the exception message, it ends up in log files and more importantly, things like exception-notification emails where it could be more readily intercepted. Logging just the missing key is enough, IMO.
